### PR TITLE
Add beat signal example and complex JSON support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,58 @@
-module for signal processing
+# pysig
+
+`pysig` provides simple classes for working with signals and spectra.  Signals
+store values against time while spectra store complex magnitudes against
+frequency.  The library includes FFT/IFFT conversion, arithmetic on aligned axes
+and interactive plotting with Plotly.  Data can also be saved to JSON or CSV.
+
+## Installation
+
+This project has no special installation steps; just copy the `pysig` package
+somewhere on your Python path.
+
+## Example
+
+```python
+import numpy as np
+import pysig as ps
+
+# build two signals with different sample times
+s1 = ps.Signal([1e-3, 2e-3, 3e-3], [1.2, 2.3, 1.9])
+s2 = ps.Signal([1e-3, 2.1e-3, 2.3e-3, 4e-3], [1.3, 2.3, 1.9, 4])
+
+# convert to spectra and combine
+sp = s1.fft() + s2.fft()
+ps.plot(ps.db(sp))
+
+# operate in the time domain
+s3 = s1 + s2
+s4 = 2 * s1
+ps.plot(s3, s4)
+
+# look up interpolated value and nearest time
+val = s3.value(time=1.3e-3)
+nearest = s3.time(1.8)
+print(val, nearest)
+
+# save and load
+s3.dump("signal.json")
+restored = ps.Signal.load("signal.json")
+
+# save and restore a spectrum
+sp.dump("spectrum.json")
+sp_back = ps.Spectrum.load("spectrum.json")
+```
+
+Additional helper functions `create` and `nrange` make it easy to generate
+test signals:
+
+```python
+# generate a sine wave from an expression
+t_axis = ps.nrange(0, 0.1, 0.001)
+sine = ps.create("sin(200*t)", t_axis)
+```
+
+A short script `example.py` demonstrates generating a beat signal by summing two
+sine waves of slightly different frequency.
+
+See [help.md](help.md) for API details.

--- a/example.py
+++ b/example.py
@@ -1,0 +1,11 @@
+import numpy as np
+import pysig as ps
+
+# Generate a beat signal by summing two sine waves with slightly different frequencies
+axis = ps.nrange(0, 1, 0.001)
+wave1 = ps.create("sin(2*np.pi*50*t)", axis)
+wave2 = ps.create("sin(2*np.pi*55*t)", axis)
+beat = wave1 + wave2
+
+# Plot the resulting beat signal
+ps.plot(beat)

--- a/help.md
+++ b/help.md
@@ -1,0 +1,27 @@
+# pysig Help
+
+`pysig` is a small utility library for manipulating time signals and frequency spectra.
+
+## Classes
+
+### `Signal`
+Represents a signal sampled at specific time points. Supports arithmetic operations, FFT conversion to `Spectrum`, and saving/loading to JSON or CSV.
+
+### `Spectrum`
+Represents a frequency spectrum with complex values. Supports arithmetic operations, IFFT conversion to `Signal`, and saving/loading.
+
+### `BaseSeries`
+Common base class used internally by `Signal` and `Spectrum`.
+
+## Functions
+
+- `create(expr, axis)`: Evaluate an expression using variable `t` (time) or `f` (frequency) to quickly build a `Signal` or `Spectrum`.
+- `nrange(start, stop, step)`: Inclusive numerical range, similar to `numpy.arange` but includes the stop value.
+- `plot(*items)`: Display signals or spectra using Plotly. The resulting figure allows interactive changes to color and line style.
+- `db(spectrum)`: Magnitude of a spectrum in decibels.
+- `sin`, `cos`, `exp`: Apply corresponding NumPy functions to a `Signal` or `Spectrum`.
+
+## Persistence
+
+Both `Signal` and `Spectrum` provide `dump(filename)` and `load(filename)` methods for storing data in JSON or CSV format. When saving complex spectra to JSON, the real and imaginary parts are stored in separate `real` and `imag` arrays.
+

--- a/pysig/__init__.py
+++ b/pysig/__init__.py
@@ -1,0 +1,316 @@
+import numpy as np
+import plotly.graph_objects as go
+import json
+import csv
+import os
+
+__all__ = [
+    "BaseSeries",
+    "Signal",
+    "Spectrum",
+    "create",
+    "nrange",
+    "plot",
+    "db",
+    "sin",
+    "cos",
+    "exp",
+]
+
+
+class BaseSeries:
+    """Base class for ordered data used by :class:`Signal` and :class:`Spectrum`."""
+
+    def __init__(self, axis, values):
+        self.x = np.asarray(axis, dtype=float)
+        self.values = np.asarray(values)
+        if self.x.shape != self.values.shape:
+            raise ValueError("axis and values must have same length")
+
+    # ---- internal helpers -------------------------------------------------
+    def _interp(self, x):
+        if np.iscomplexobj(self.values):
+            real = np.interp(x, self.x, self.values.real)
+            imag = np.interp(x, self.x, self.values.imag)
+            return real + 1j * imag
+        return np.interp(x, self.x, self.values)
+
+    def _binary_op(self, other, func):
+        if isinstance(other, self.__class__):
+            x = np.union1d(self.x, other.x)
+            v1 = self._interp(x)
+            v2 = other._interp(x)
+            return self.__class__(x, func(v1, v2))
+        raise TypeError(f"Can only operate with {self.__class__.__name__}")
+
+    # ---- arithmetic operations --------------------------------------------
+    def __add__(self, other):
+        return self._binary_op(other, lambda a, b: a + b)
+
+    def __radd__(self, other):
+        return self.__add__(other)
+
+    def __sub__(self, other):
+        return self._binary_op(other, lambda a, b: a - b)
+
+    def __rsub__(self, other):
+        if isinstance(other, self.__class__):
+            return other.__sub__(self)
+        raise TypeError(f"Can only subtract {self.__class__.__name__}")
+
+    def __mul__(self, other):
+        if np.isscalar(other):
+            return self.__class__(self.x, self.values * other)
+        raise TypeError("Can only multiply by scalar")
+
+    def __rmul__(self, other):
+        return self.__mul__(other)
+
+    def __truediv__(self, other):
+        if np.isscalar(other):
+            return self.__class__(self.x, self.values / other)
+        raise TypeError("Can only divide by scalar")
+
+    def __rtruediv__(self, other):
+        if np.isscalar(other):
+            return self.__class__(self.x, other / self.values)
+        raise TypeError("Can only divide by scalar numerator")
+
+    def __neg__(self):
+        return self.__class__(self.x, -self.values)
+
+    # ---- persistence ------------------------------------------------------
+    def dump(self, filename):
+        """Save data to ``filename`` in JSON or CSV format."""
+        ext = os.path.splitext(filename)[1].lower()
+        if ext == ".json":
+            with open(filename, "w", encoding="utf-8") as f:
+                if np.iscomplexobj(self.values):
+                    json.dump(
+                        {
+                            "axis": self.x.tolist(),
+                            "real": self.values.real.tolist(),
+                            "imag": self.values.imag.tolist(),
+                        },
+                        f,
+                    )
+                else:
+                    json.dump(
+                        {
+                            "axis": self.x.tolist(),
+                            "values": self.values.tolist(),
+                        },
+                        f,
+                    )
+        elif ext == ".csv":
+            with open(filename, "w", newline="") as f:
+                writer = csv.writer(f)
+                if np.iscomplexobj(self.values):
+                    writer.writerow(["axis", "real", "imag"])
+                    for x, v in zip(self.x, self.values):
+                        writer.writerow([x, float(v.real), float(v.imag)])
+                else:
+                    writer.writerow(["axis", "value"])
+                    for x, v in zip(self.x, self.values):
+                        writer.writerow([x, float(v)])
+        else:
+            raise ValueError("Unsupported file extension")
+
+    @classmethod
+    def load(cls, filename):
+        """Load data from ``filename`` and return a new instance."""
+        ext = os.path.splitext(filename)[1].lower()
+        if ext == ".json":
+            with open(filename, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            axis = data["axis"]
+            if "real" in data and "imag" in data:
+                values = np.array(data["real"]) + 1j * np.array(data["imag"])
+            else:
+                values = data["values"]
+        elif ext == ".csv":
+            with open(filename, "r", newline="") as f:
+                reader = csv.reader(f)
+                header = next(reader)
+                axis = []
+                values = []
+                for row in reader:
+                    axis.append(float(row[0]))
+                    if header == ["axis", "real", "imag"]:
+                        values.append(float(row[1]) + 1j * float(row[2]))
+                    else:
+                        values.append(float(row[1]))
+        else:
+            raise ValueError("Unsupported file extension")
+
+        return cls(axis, values)
+
+class Signal(BaseSeries):
+    """Simple signal class representing values over time."""
+
+    def __init__(self, times, values):
+        super().__init__(times, np.asarray(values, dtype=float))
+
+    @property
+    def times(self):
+        return self.x
+
+
+    def value(self, time):
+        """Return signal value interpolated at given time."""
+        return float(np.interp(time, self.times, self.values))
+
+    def time(self, value):
+        """Return time closest to the given value."""
+        idx = np.argmin(np.abs(self.values - value))
+        return float(self.times[idx])
+
+    def fft(self, n=None):
+        """Return the spectrum using FFT. Resamples to a uniform grid."""
+        if n is None:
+            n = len(self.values)
+        # create uniform grid
+        t_min = self.times.min()
+        t_max = self.times.max()
+        uniform_t = np.linspace(t_min, t_max, len(self.values))
+        uniform_v = np.interp(uniform_t, self.times, self.values)
+        freqs = np.fft.rfftfreq(n, d=(uniform_t[1] - uniform_t[0]))
+        spec = np.fft.rfft(uniform_v, n)
+        return Spectrum(freqs, spec)
+
+
+class Spectrum(BaseSeries):
+    """Frequency spectrum with complex values."""
+
+    def __init__(self, freqs, values):
+        super().__init__(freqs, np.asarray(values, dtype=complex))
+
+    @property
+    def freqs(self):
+        return self.x
+
+
+    def ifft(self, n=None):
+        """Return the time-domain signal using IFFT."""
+        if n is None:
+            n = 2 * (len(self.freqs) - 1)
+        if len(self.freqs) > 1:
+            dt = 1.0 / ((self.freqs[1] - self.freqs[0]) * n)
+        else:
+            dt = 1.0
+        times = np.arange(n) * dt
+        values = np.fft.irfft(self.values, n)
+        return Signal(times, values)
+
+
+def _apply_unary(func, obj):
+    if isinstance(obj, BaseSeries):
+        return obj.__class__(obj.x, func(obj.values))
+    raise TypeError("Unsupported type for unary operation")
+
+
+def sin(obj):
+    """Return the sine of a signal or spectrum."""
+    return _apply_unary(np.sin, obj)
+
+
+def cos(obj):
+    """Return the cosine of a signal or spectrum."""
+    return _apply_unary(np.cos, obj)
+
+
+def exp(obj):
+    """Return the exponential of a signal or spectrum."""
+    return _apply_unary(np.exp, obj)
+
+
+def db(spectrum):
+    """Return magnitude of spectrum in dB."""
+    return 20 * np.log10(np.abs(spectrum.values))
+
+
+def plot(*items):
+    """Plot signals or spectra using plotly.
+
+    The resulting figure supports interactive changes to color and line
+    style through the plotly UI."""
+    fig = go.Figure()
+    for idx, item in enumerate(items):
+        if isinstance(item, Signal):
+            fig.add_trace(
+                go.Scatter(
+                    x=item.times,
+                    y=item.values,
+                    mode="lines",
+                    name=f"Signal {idx}",
+                )
+            )
+        elif isinstance(item, Spectrum):
+            fig.add_trace(
+                go.Scatter(
+                    x=item.freqs,
+                    y=np.abs(item.values),
+                    mode="lines",
+                    name=f"Spectrum {idx}",
+                )
+            )
+        else:
+            fig.add_trace(
+                go.Scatter(
+                    y=np.asarray(item),
+                    mode="lines",
+                    name=f"Data {idx}",
+                )
+            )
+    fig.update_layout(
+        xaxis_title="Time/Frequency",
+        yaxis_title="Amplitude",
+    )
+    fig.show()
+
+
+def nrange(start, stop, step):
+    """Return inclusive range similar to :func:`numpy.arange`."""
+    return np.arange(start, stop + step, step)
+
+
+def create(expr, axis):
+    """Create a :class:`Signal` or :class:`Spectrum` from an expression.
+
+    Parameters
+    ----------
+    expr : str
+        Expression involving either variable ``t`` for time or ``f`` for
+        frequency.  The expression may use numpy functions such as ``sin``,
+        ``cos`` and ``exp``.
+    axis : array_like
+        Values for ``t`` or ``f``.
+
+    Returns
+    -------
+    Signal or Spectrum
+        The newly generated object depending on the variable used in
+        ``expr``.
+    """
+
+    axis = np.asarray(axis, dtype=float)
+    env = {
+        "np": np,
+        "sin": np.sin,
+        "cos": np.cos,
+        "exp": np.exp,
+    }
+
+    if "t" in expr and "f" in expr:
+        raise ValueError("expression should not contain both 't' and 'f'")
+
+    if "t" in expr:
+        env["t"] = axis
+        values = eval(expr, {"__builtins__": {}}, env)
+        return Signal(axis, values)
+    if "f" in expr:
+        env["f"] = axis
+        values = eval(expr, {"__builtins__": {}}, env)
+        return Spectrum(axis, values)
+
+    raise ValueError("expression must contain either 't' or 'f'")

--- a/test.py
+++ b/test.py
@@ -1,0 +1,42 @@
+import numpy as np
+import pysig as ps
+
+
+def sample_signals():
+    """Return two example signals of different lengths."""
+    s1 = ps.Signal([1e-3, 2e-3, 3e-3], [1.2, 2.3, 1.9])
+    s2 = ps.Signal([1e-3, 2.1e-3, 2.3e-3, 4e-3], [1.3, 2.3, 1.9, 4])
+    return s1, s2
+
+
+def test_fft_plot():
+    """Combine spectra of two signals and plot in dB."""
+    s1, s2 = sample_signals()
+    sp = s1.fft() + s2.fft()
+    ps.plot(ps.db(sp))
+
+
+def test_time_ops():
+    """Perform simple arithmetic on signals and display results."""
+    s1, s2 = sample_signals()
+    s3 = s1 + s2
+    s4 = 2 * s1
+    ps.plot(s3, s4)
+    print("value at 1.3e-3:", s3.value(1.3e-3))
+    print("closest time to 1.8:", s3.time(1.8))
+
+
+def test_create_save_load():
+    """Generate a sine wave, save and reload from JSON."""
+    axis = ps.nrange(0, 0.01, 0.001)
+    sig = ps.create("sin(200*t)", axis)
+    filename = "temp_signal.json"
+    sig.dump(filename)
+    restored = ps.Signal.load(filename)
+    print("round-trip equal:", np.allclose(sig.values, restored.values))
+
+
+if __name__ == "__main__":
+    test_fft_plot()
+    test_time_ops()
+    test_create_save_load()


### PR DESCRIPTION
## Summary
- handle complex number persistence for JSON files
- document complex JSON format in `help.md`
- show how to save and load a `Spectrum` in `README.md`
- provide `example.py` demonstrating a beat signal

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6844e08c3548832a8d4a24d5511ecfa8